### PR TITLE
DCM treats null topic.id as '-' because it represent 'no intent'

### DIFF
--- a/dist/core/DialogueContextManager.js
+++ b/dist/core/DialogueContextManager.js
@@ -149,21 +149,27 @@ var DialogueContextManager = function () {
               case 0:
                 this.vLog("DialogueContextManager#getNewContext called");
                 _context2.prev = 1;
+
+                // DCM treats null topic.id as '-' (no intent)
+                if (newInput.body.topic && newInput.body.topic.id === null) {
+                  newInput.body.topic.id = "-";
+                }
+
                 errors = this.validateInput((newInput || {}).body);
 
                 if (!(errors.length > 0)) {
-                  _context2.next = 6;
+                  _context2.next = 7;
                   break;
                 }
 
                 console.error(errors.join("\n"));
                 throw new Error("DialogueContextManager#getNewContext invalid input");
 
-              case 6:
+              case 7:
                 this.vLog("input validation done");
 
                 // contextをredisから取得
-                _context2.next = 9;
+                _context2.next = 10;
                 return _Context2.default.getOrInitial(
                 // this.applicationId,
                 userId, _redisPool2.default.getPool(this.redis), {
@@ -172,24 +178,24 @@ var DialogueContextManager = function () {
                   holdUsedSlot: this.holdUsedSlot
                 });
 
-              case 9:
+              case 10:
                 context = _context2.sent;
 
                 this.vLog("get context done");
 
                 // contextをupdateする
-                _context2.next = 13;
+                _context2.next = 14;
                 return context.update(newInput);
 
-              case 13:
+              case 14:
                 context.forget();
                 this.vLog("update context done");
 
                 // contextからconditionゲット
-                _context2.next = 17;
+                _context2.next = 18;
                 return this.ruleMap.get();
 
-              case 17:
+              case 18:
                 ruleMap = _context2.sent;
                 matchedCondition = new _Conditions2.default(ruleMap, this.extraSlotKeys, context).getMatchedCondition();
 
@@ -197,29 +203,29 @@ var DialogueContextManager = function () {
                 this.vLog("pickup condition done");
 
                 // contextを永続化
-                _context2.next = 23;
+                _context2.next = 24;
                 return context.persist();
 
-              case 23:
+              case 24:
                 this.vLog("persist context done");
 
                 // contextを返却
                 return _context2.abrupt("return", context);
 
-              case 27:
-                _context2.prev = 27;
+              case 28:
+                _context2.prev = 28;
                 _context2.t0 = _context2["catch"](1);
 
                 console.error("Error on DialogueContextManager#getNewContext");
                 console.error(_context2.t0);
                 throw new Error(_context2.t0);
 
-              case 32:
+              case 33:
               case "end":
                 return _context2.stop();
             }
           }
-        }, _callee2, this, [[1, 27]]);
+        }, _callee2, this, [[1, 28]]);
       }));
 
       function getNewContext(_x3, _x4) {

--- a/lib/core/DialogueContextManager.js
+++ b/lib/core/DialogueContextManager.js
@@ -86,6 +86,11 @@ export default class DialogueContextManager {
   async getNewContext(userId, newInput) {
     this.vLog("DialogueContextManager#getNewContext called");
     try {
+      // DCM treats null topic.id as '-' (no intent)
+      if (newInput.body.topic && newInput.body.topic.id === null) {
+        newInput.body.topic.id = '-'
+      }
+
       const errors = this.validateInput((newInput || {}).body);
       if (errors.length > 0) {
         console.error(errors.join("\n"));

--- a/lib/core/DialogueContextManager.js
+++ b/lib/core/DialogueContextManager.js
@@ -88,7 +88,7 @@ export default class DialogueContextManager {
     try {
       // DCM treats null topic.id as '-' (no intent)
       if (newInput.body.topic && newInput.body.topic.id === null) {
-        newInput.body.topic.id = '-'
+        newInput.body.topic.id = "-";
       }
 
       const errors = this.validateInput((newInput || {}).body);

--- a/test/core/DialogueContextManager.spec.js
+++ b/test/core/DialogueContextManager.spec.js
@@ -37,8 +37,8 @@ describe("DialogueContext", ()=>{
     it ("ApplicationIDなしで例外Throw", ()=>{
       expect(() => new DialogueContextManager( delete testOptions().applicationId )).to.throw(Error);
     });
-
   });
+
   context("#validateInput", ()=>{
     it ("extraSlotKeysに指定されているkeyで、keywordの無いもの(空文字は許可)を弾く", ()=>{
       const m = new DialogueContextManager( testOptions() );
@@ -63,6 +63,14 @@ describe("DialogueContext", ()=>{
       const m = new DialogueContextManager( testOptions() );
       expect( m.validateInput({ target: { type: "", keyword: ""}, hoge: { keyword: "" }, topic: { id: "id" } }) ).to.be.empty;
       expect( m.validateInput({ target: { }, hoge: { }, topic: { } }) ).to.have.lengthOf(3);
+    });
+  });
+
+  context("#getNewContext", () => {
+    it("topic idがnullのとき'-'に置換される", async () => {
+      const m = new DialogueContextManager(testOptions());
+      const ctx = await m.getNewContext("dummyUser000", { body: { topic: { id: null } } });
+      expect(ctx.latestInput.body.topic.id).equals("-");
     });
   });
 


### PR DESCRIPTION
インテント用のaNOiがインテントを`null`で返してくる場合がある。
現状、DCMの`topic` (インテントのこと) が `null`になるとバリデーションでエラーとなる。

この`null`はユーザ発話の*意図がない*ことを意味しているので、`発話意図なし`を表す`-`に変換する必要があるので修正した。

背景issue: https://github.com/Nextremer/minarai-sawachi-dcm/issues/23