### PR TITLE
Redisの非同期関連の処置漏れ修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ We really don't like this name. Pull request that changes the name of library, i
 ## install
 
 * Githubアカウントとssh_keyを紐付けている場合は下記でインストールが可能です
+* 適宜 tag (v0.y.z) を指定してください。
+
 
 ```
 npm install Nextremer/minarai-sawachi-dcm --save
@@ -37,14 +39,12 @@ npm install Nextremer/minarai-sawachi-dcm --save
 
 その上で、 `npm install` でインストールできます。
 
-
-
 ## Example 
 
 リファレンスについては次の項を参照。
-Babel,ES5環境におけるコードサンプルを以下に提示します。
+ES7 + babel環境におけるコードサンプルを以下に提示します。
 
-###  with babel 
+### ES7 with babel
 
 ```js
 import DialogueContextManager from "dialogue-context-manager";
@@ -77,7 +77,7 @@ const options = {
 };
 
 async function main(){
-  const contextManager = new DialogueContextManager( options );
+  const contextManager = await DialogueContextManager.getInstance( options );
   const input = {
     isAvailable: true,
     body: {
@@ -101,75 +101,11 @@ async function main(){
 main();
 ```
 
-### ES5
-
-```js
-var DialogueContextManager = require( "dialogue-context-manager" ).default;
-
-var conditionMap = [{
-  topic: "profile",
-  target: "something",
-  slot1: "foo",
-  slot2: "-",
-  slot3: "-",
-  actionId: "someaction"
-}];
-
-var options = {
-  applicationId: APPLICATION_ID, // 必須
-  conditionMap: {
-    source: "object",
-    sourceOptions: {
-      map: conditionMap,
-    },
-    fetchForEachRequest: false,
-  },
-  redis: {
-    connectionString: "redis://HOST:PORT" // CHANGE ME!
-  },
-  extraSlotKeys: ["slot1", "slot2", "slot3" ],
-  initialLifeSpan: 2,
-  holdUsedSlot: true,
-  verbose: true,
-};
-
-function main(){
-  var contextManager = new DialogueContextManager( options );
-  var input = {
-    isAvailable: true,
-    body: {
-      slot1: { keyword: "foo" }
-    }
-  };
-
-  // "testUserId" はシステムで Unique であること
-  contextManager.getNewContext( "testUserId", input )
-    .then( ( context )=>{
-
-      console.log( context.matchedCondition );  // matchedCondition.actionId 
-      console.log( context.body ); // you can access
-
-      // you can also set any key and value you want under context.extra. 
-      console.log( context.extra ); 
-      context.extra.hoge = "1"; 
-
-      // to persist context manually, call #persist method
-      context.persist();
-
-    }).catch(( error )=>{
-      console.log ( error );
-    });
-
-};
-
-main();
-```
-
 ## Configurations
 
 先の例に挙げたとおり `DialogueContextManager` のコンストラクタに渡す `options` は次のようになっている。
 
-```ecmascript 6
+```js
 const options = {
   applicationId: APPLICATION_ID, // 必須
   conditionMap: {
@@ -180,7 +116,11 @@ const options = {
     fetchForEachRequest: false,
   },
   redis: {
-    connectionString: "redis://HOST:PORT" // CHANGE ME!
+    connectionString: "redis://HOST:PORT", // CHANGE ME!
+    options: {  // Optional
+      auth_pass: "PASSWORD",
+      tls: {}
+    }
   },
   extraSlotKeys: ["slot1", "slot2", "slot3" ],
   initialLifeSpan: 2,
@@ -204,6 +144,31 @@ const options = {
 これは `source: "object"` で `map` に `JSON.parse(json)` を設定したものと等価。
 
 `conditionMap` そのものを設定しない (キーを持たせない) 場合には ConditionMap を Redis から取得するよう指示したものと解釈する。
+
+
+### Redis 接続設定
+
+Redis接続時の追加オプションに対応している。
+
+```js
+  redis: {
+    connectionString: "redis://HOST_ADDRESS:PORT",
+    options: {
+      auth_pass: "PASSWORD",
+      tls: {}
+    }
+  },
+```
+
+`connectionString` はRedisのURIを指定する。通常 `redis://host_address:port` の書式を用いる。
+URIスキーマはTLS接続の場合も `redis://` を使用すること（ `rediss://` は Warning が表示される)。
+
+`options` には追加オプションを指定する。
+認証が必要な場合には `auth_pass` が必要。
+また、TLS接続をする場合には、 `tls` が必要。 `tls` に設定可能な値は次のドキュメントを参照のこと。
+
+https://nodejs.org/docs/latest-v8.x/api/tls.html#tls_tls_connect_options_callback
+
 
 ## Redis上のConditionMap存在確認の方法
 
@@ -236,7 +201,7 @@ ConditionMap については読み出しのタイミングで有効期限を延�
 ```js
 
 // getting DialogueContextManagerInstance ( singleton )
-const contextManager = new DialogueContextManager( options );
+const contextManager = await DialogueContextManager.getInstance( options );
 
 // getting new context
 //   see input interface

--- a/dist/core/ConditionMap.js
+++ b/dist/core/ConditionMap.js
@@ -38,64 +38,44 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 var rp = require("request-promise");
 
 var ConditionMap = exports.ConditionMap = function () {
-  (0, _createClass3.default)(ConditionMap, null, [{
-    key: "getInstance",
-    value: function getInstance(applicationId, conditionMapOptions, redisConfig) {
-      return new ConditionMap(applicationId, conditionMapOptions, redisConfig);
-    }
-
-    //TODO: BluebirdのRedisでキーの存在チェックできる？
-
-  }]);
-
-  function ConditionMap(applicationId, conditionMapOptions, redisConfig) {
+  function ConditionMap() {
     (0, _classCallCheck3.default)(this, ConditionMap);
     this.map = null;
-
-    if (applicationId === undefined || applicationId === null || applicationId === "") {
-      throw new Error("applicationId is invalid: " + applicationId);
-    }
-
-    conditionMapOptions.applicationId = applicationId;
-    conditionMapOptions.redis = redisConfig;
-
-    this.source = this._sourceSelector(conditionMapOptions);
-    this.fetchForEachRequest = conditionMapOptions.fetchForEachRequest;
   }
 
   (0, _createClass3.default)(ConditionMap, [{
-    key: "_sourceSelector",
-    value: function _sourceSelector(conditionMapOptions) {
-      var source = conditionMapOptions.source;
-      if (source === "json") return new MapResourceJson(conditionMapOptions);
-      if (source === "object") return new MapResourceObject(conditionMapOptions);
-      if (source === "redis") return new MapResourceRedis(conditionMapOptions);
-      if (source === "testLocal") return new MapResourceLocal(conditionMapOptions);
-      throw new Error("No valid source type specified: " + source);
-    }
-  }, {
-    key: "fetch",
+    key: "_init",
+
+
+    //TODO: BluebirdのRedisでキーの存在チェックできる？
+
     value: function () {
-      var _ref = (0, _asyncToGenerator3.default)( /*#__PURE__*/_regenerator2.default.mark(function _callee() {
-        var map;
+      var _ref = (0, _asyncToGenerator3.default)( /*#__PURE__*/_regenerator2.default.mark(function _callee(applicationId, conditionMapOptions, redisConfig) {
         return _regenerator2.default.wrap(function _callee$(_context) {
           while (1) {
             switch (_context.prev = _context.next) {
               case 0:
-                if (!(this.fetchForEachRequest || !this.map)) {
-                  _context.next = 5;
+                if (!(applicationId === undefined || applicationId === null || applicationId === "")) {
+                  _context.next = 2;
                   break;
                 }
 
-                _context.next = 3;
-                return this.source.fetch();
+                throw new Error("applicationId is invalid: " + applicationId);
 
-              case 3:
-                map = _context.sent;
+              case 2:
 
-                this.map = map;
+                conditionMapOptions.applicationId = applicationId;
+                conditionMapOptions.redis = redisConfig;
 
-              case 5:
+                _context.next = 6;
+                return this._sourceSelector(conditionMapOptions);
+
+              case 6:
+                this.source = _context.sent;
+
+                this.fetchForEachRequest = conditionMapOptions.fetchForEachRequest;
+
+              case 8:
               case "end":
                 return _context.stop();
             }
@@ -103,27 +83,70 @@ var ConditionMap = exports.ConditionMap = function () {
         }, _callee, this);
       }));
 
-      function fetch() {
+      function _init(_x, _x2, _x3) {
         return _ref.apply(this, arguments);
       }
 
-      return fetch;
+      return _init;
     }()
   }, {
-    key: "get",
+    key: "_sourceSelector",
     value: function () {
-      var _ref2 = (0, _asyncToGenerator3.default)( /*#__PURE__*/_regenerator2.default.mark(function _callee2() {
+      var _ref2 = (0, _asyncToGenerator3.default)( /*#__PURE__*/_regenerator2.default.mark(function _callee2(conditionMapOptions) {
+        var source;
         return _regenerator2.default.wrap(function _callee2$(_context2) {
           while (1) {
             switch (_context2.prev = _context2.next) {
               case 0:
-                _context2.next = 2;
-                return this.getMap();
+                source = conditionMapOptions.source;
 
-              case 2:
+                if (!(source === "json")) {
+                  _context2.next = 5;
+                  break;
+                }
+
+                _context2.next = 4;
+                return MapResource.initializeWithJSON(conditionMapOptions);
+
+              case 4:
                 return _context2.abrupt("return", _context2.sent);
 
-              case 3:
+              case 5:
+                if (!(source === "object")) {
+                  _context2.next = 9;
+                  break;
+                }
+
+                _context2.next = 8;
+                return MapResource.initializeWithObject(conditionMapOptions);
+
+              case 8:
+                return _context2.abrupt("return", _context2.sent);
+
+              case 9:
+                if (!(source === "redis")) {
+                  _context2.next = 13;
+                  break;
+                }
+
+                _context2.next = 12;
+                return MapResource.initializeWithRedis(conditionMapOptions);
+
+              case 12:
+                return _context2.abrupt("return", _context2.sent);
+
+              case 13:
+                if (!(source === "testLocal")) {
+                  _context2.next = 15;
+                  break;
+                }
+
+                return _context2.abrupt("return", new MapResourceLocal(conditionMapOptions));
+
+              case 15:
+                throw new Error("No valid source type specified: " + source);
+
+              case 16:
               case "end":
                 return _context2.stop();
             }
@@ -131,27 +154,35 @@ var ConditionMap = exports.ConditionMap = function () {
         }, _callee2, this);
       }));
 
-      function get() {
+      function _sourceSelector(_x4) {
         return _ref2.apply(this, arguments);
       }
 
-      return get;
+      return _sourceSelector;
     }()
   }, {
-    key: "getMap",
+    key: "fetch",
     value: function () {
       var _ref3 = (0, _asyncToGenerator3.default)( /*#__PURE__*/_regenerator2.default.mark(function _callee3() {
+        var map;
         return _regenerator2.default.wrap(function _callee3$(_context3) {
           while (1) {
             switch (_context3.prev = _context3.next) {
               case 0:
-                _context3.next = 2;
-                return this.fetch();
+                if (!(this.fetchForEachRequest || !this.map)) {
+                  _context3.next = 5;
+                  break;
+                }
 
-              case 2:
-                return _context3.abrupt("return", this.map.conditionMap);
+                _context3.next = 3;
+                return this.source.fetch();
 
               case 3:
+                map = _context3.sent;
+
+                this.map = map;
+
+              case 5:
               case "end":
                 return _context3.stop();
             }
@@ -159,14 +190,14 @@ var ConditionMap = exports.ConditionMap = function () {
         }, _callee3, this);
       }));
 
-      function getMap() {
+      function fetch() {
         return _ref3.apply(this, arguments);
       }
 
-      return getMap;
+      return fetch;
     }()
   }, {
-    key: "getExtraSlotKeys",
+    key: "get",
     value: function () {
       var _ref4 = (0, _asyncToGenerator3.default)( /*#__PURE__*/_regenerator2.default.mark(function _callee4() {
         return _regenerator2.default.wrap(function _callee4$(_context4) {
@@ -174,10 +205,10 @@ var ConditionMap = exports.ConditionMap = function () {
             switch (_context4.prev = _context4.next) {
               case 0:
                 _context4.next = 2;
-                return this.fetch();
+                return this.getMap();
 
               case 2:
-                return _context4.abrupt("return", this.map.extraSlotKeys);
+                return _context4.abrupt("return", _context4.sent);
 
               case 3:
               case "end":
@@ -187,8 +218,64 @@ var ConditionMap = exports.ConditionMap = function () {
         }, _callee4, this);
       }));
 
-      function getExtraSlotKeys() {
+      function get() {
         return _ref4.apply(this, arguments);
+      }
+
+      return get;
+    }()
+  }, {
+    key: "getMap",
+    value: function () {
+      var _ref5 = (0, _asyncToGenerator3.default)( /*#__PURE__*/_regenerator2.default.mark(function _callee5() {
+        return _regenerator2.default.wrap(function _callee5$(_context5) {
+          while (1) {
+            switch (_context5.prev = _context5.next) {
+              case 0:
+                _context5.next = 2;
+                return this.fetch();
+
+              case 2:
+                return _context5.abrupt("return", this.map.conditionMap);
+
+              case 3:
+              case "end":
+                return _context5.stop();
+            }
+          }
+        }, _callee5, this);
+      }));
+
+      function getMap() {
+        return _ref5.apply(this, arguments);
+      }
+
+      return getMap;
+    }()
+  }, {
+    key: "getExtraSlotKeys",
+    value: function () {
+      var _ref6 = (0, _asyncToGenerator3.default)( /*#__PURE__*/_regenerator2.default.mark(function _callee6() {
+        return _regenerator2.default.wrap(function _callee6$(_context6) {
+          while (1) {
+            switch (_context6.prev = _context6.next) {
+              case 0:
+                _context6.next = 2;
+                return this.fetch();
+
+              case 2:
+                return _context6.abrupt("return", this.map.extraSlotKeys);
+
+              case 3:
+              case "end":
+                return _context6.stop();
+            }
+          }
+        }, _callee6, this);
+      }));
+
+      function getExtraSlotKeys() {
+        return _ref6.apply(this, arguments);
       }
 
       return getExtraSlotKeys;
@@ -211,12 +298,136 @@ var ConditionMap = exports.ConditionMap = function () {
     value: function clear() {
       this.map = null;
     }
+  }], [{
+    key: "getInstance",
+    value: function () {
+      var _ref7 = (0, _asyncToGenerator3.default)( /*#__PURE__*/_regenerator2.default.mark(function _callee7(applicationId, conditionMapOptions, redisConfig) {
+        var cm;
+        return _regenerator2.default.wrap(function _callee7$(_context7) {
+          while (1) {
+            switch (_context7.prev = _context7.next) {
+              case 0:
+                cm = new ConditionMap();
+                _context7.next = 3;
+                return cm._init(applicationId, conditionMapOptions, redisConfig);
+
+              case 3:
+                return _context7.abrupt("return", cm);
+
+              case 4:
+              case "end":
+                return _context7.stop();
+            }
+          }
+        }, _callee7, this);
+      }));
+
+      function getInstance(_x5, _x6, _x7) {
+        return _ref7.apply(this, arguments);
+      }
+
+      return getInstance;
+    }()
   }]);
   return ConditionMap;
 }();
 
 var MapResource = function () {
+  (0, _createClass3.default)(MapResource, null, [{
+    key: "initializeWithJSON",
+    value: function () {
+      var _ref8 = (0, _asyncToGenerator3.default)( /*#__PURE__*/_regenerator2.default.mark(function _callee8(conditionMapOptions) {
+        var res;
+        return _regenerator2.default.wrap(function _callee8$(_context8) {
+          while (1) {
+            switch (_context8.prev = _context8.next) {
+              case 0:
+                res = new MapResourceJson(conditionMapOptions);
+                _context8.next = 3;
+                return res.init();
+
+              case 3:
+                return _context8.abrupt("return", res);
+
+              case 4:
+              case "end":
+                return _context8.stop();
+            }
+          }
+        }, _callee8, this);
+      }));
+
+      function initializeWithJSON(_x8) {
+        return _ref8.apply(this, arguments);
+      }
+
+      return initializeWithJSON;
+    }()
+  }, {
+    key: "initializeWithObject",
+    value: function () {
+      var _ref9 = (0, _asyncToGenerator3.default)( /*#__PURE__*/_regenerator2.default.mark(function _callee9(conditionMapOptions) {
+        var res;
+        return _regenerator2.default.wrap(function _callee9$(_context9) {
+          while (1) {
+            switch (_context9.prev = _context9.next) {
+              case 0:
+                res = new MapResourceObject(conditionMapOptions);
+                _context9.next = 3;
+                return res.init();
+
+              case 3:
+                return _context9.abrupt("return", res);
+
+              case 4:
+              case "end":
+                return _context9.stop();
+            }
+          }
+        }, _callee9, this);
+      }));
+
+      function initializeWithObject(_x9) {
+        return _ref9.apply(this, arguments);
+      }
+
+      return initializeWithObject;
+    }()
+  }, {
+    key: "initializeWithRedis",
+    value: function () {
+      var _ref10 = (0, _asyncToGenerator3.default)( /*#__PURE__*/_regenerator2.default.mark(function _callee10(conditionMapOptions) {
+        var res;
+        return _regenerator2.default.wrap(function _callee10$(_context10) {
+          while (1) {
+            switch (_context10.prev = _context10.next) {
+              case 0:
+                res = new MapResourceRedis(conditionMapOptions);
+                _context10.next = 3;
+                return res.init();
+
+              case 3:
+                return _context10.abrupt("return", res);
+
+              case 4:
+              case "end":
+                return _context10.stop();
+            }
+          }
+        }, _callee10, this);
+      }));
+
+      function initializeWithRedis(_x10) {
+        return _ref10.apply(this, arguments);
+      }
+
+      return initializeWithRedis;
+    }()
+  }]);
+
   function MapResource(conditionMapOptions) {
+    var _this = this;
+
     (0, _classCallCheck3.default)(this, MapResource);
     var applicationId = conditionMapOptions.applicationId,
         redis = conditionMapOptions.redis,
@@ -231,72 +442,109 @@ var MapResource = function () {
     if (!(extraSlotKeys === undefined && extraSlotKeys instanceof Array)) {
       this.extraSlotKeys = extraSlotKeys;
     }
+
+    this._init = (0, _asyncToGenerator3.default)( /*#__PURE__*/_regenerator2.default.mark(function _callee11() {
+      return _regenerator2.default.wrap(function _callee11$(_context11) {
+        while (1) {
+          switch (_context11.prev = _context11.next) {
+            case 0:
+            case "end":
+              return _context11.stop();
+          }
+        }
+      }, _callee11, _this);
+    }));
   }
 
-  /**
-   * RedisからConditionMapの内容を取得する
-   *
-   * インスタンス生成時にextraSlotKeysが設定されていれば、
-   * 取得したConditionMapに関連するextraSlotKeysを、
-   * インスタンス生成時のもので上書きをする。
-   *
-   * @returns conditionMapの内容
-   * @throws Error RedisからconditionMapの取得に失敗したとき例外 `Error` を送出する。
-   */
-
-
   (0, _createClass3.default)(MapResource, [{
+    key: "init",
+    value: function () {
+      var _ref12 = (0, _asyncToGenerator3.default)( /*#__PURE__*/_regenerator2.default.mark(function _callee12() {
+        return _regenerator2.default.wrap(function _callee12$(_context12) {
+          while (1) {
+            switch (_context12.prev = _context12.next) {
+              case 0:
+                _context12.next = 2;
+                return this._init();
+
+              case 2:
+              case "end":
+                return _context12.stop();
+            }
+          }
+        }, _callee12, this);
+      }));
+
+      function init() {
+        return _ref12.apply(this, arguments);
+      }
+
+      return init;
+    }()
+
+    /**
+     * RedisからConditionMapの内容を取得する
+     *
+     * インスタンス生成時にextraSlotKeysが設定されていれば、
+     * 取得したConditionMapに関連するextraSlotKeysを、
+     * インスタンス生成時のもので上書きをする。
+     *
+     * @returns conditionMapの内容
+     * @throws Error RedisからconditionMapの取得に失敗したとき例外 `Error` を送出する。
+     */
+
+  }, {
     key: "fetch",
     value: function () {
-      var _ref5 = (0, _asyncToGenerator3.default)( /*#__PURE__*/_regenerator2.default.mark(function _callee5() {
-        var _this = this;
+      var _ref13 = (0, _asyncToGenerator3.default)( /*#__PURE__*/_regenerator2.default.mark(function _callee13() {
+        var _this2 = this;
 
         var redisPool, map;
-        return _regenerator2.default.wrap(function _callee5$(_context5) {
+        return _regenerator2.default.wrap(function _callee13$(_context13) {
           while (1) {
-            switch (_context5.prev = _context5.next) {
+            switch (_context13.prev = _context13.next) {
               case 0:
                 redisPool = _redisPool2.default.getPool(this.redis);
-                _context5.next = 3;
+                _context13.next = 3;
                 return redisPool.getAsync("ConditionMap/" + this.applicationId).then(function (res) {
                   return JSON.parse(res);
                 }).catch(function () {
-                  throw new Error("Unable to retrieve a condition map from redis for application " + _this.applicationId);
+                  throw new Error("Unable to retrieve a condition map from redis for application " + _this2.applicationId);
                 });
 
               case 3:
-                map = _context5.sent;
+                map = _context13.sent;
 
-                if (!(map instanceof Array)) {
-                  _context5.next = 8;
+                if (!Array.isArray(map)) {
+                  _context13.next = 8;
                   break;
                 }
 
                 // 取得したものが配列なら extraSlotKeys 情報が付加されていない ConditionMap とみなす
                 map = { conditionMap: map, extraSlotKeys: [] };
                 //TODO: map の内容から extraSlotKeysを推論させる？
-                _context5.next = 16;
+                _context13.next = 16;
                 break;
 
               case 8:
                 if (!(map instanceof Object && map.hasOwnProperty("topic"))) {
-                  _context5.next = 12;
+                  _context13.next = 12;
                   break;
                 }
 
                 // 取得したものがオブジェクトだったら ConditionMap の単体が入っている可能性もある
                 // topic keyがあるかどうかで判定
                 map = { conditionMap: [map], extraSlotKeys: [] };
-                _context5.next = 16;
+                _context13.next = 16;
                 break;
 
               case 12:
                 if (!(map instanceof Object && map.hasOwnProperty("conditionMap"))) {
-                  _context5.next = 15;
+                  _context13.next = 15;
                   break;
                 }
 
-                _context5.next = 16;
+                _context13.next = 16;
                 break;
 
               case 15:
@@ -311,41 +559,65 @@ var MapResource = function () {
                 this.map = map;
 
                 // Redis の有効期限を延長しておく
-                _context5.next = 20;
+                _context13.next = 20;
                 return this.updateRedisTtl();
 
               case 20:
-                return _context5.abrupt("return", map);
+                return _context13.abrupt("return", map);
 
               case 21:
               case "end":
-                return _context5.stop();
+                return _context13.stop();
             }
           }
-        }, _callee5, this);
+        }, _callee13, this);
       }));
 
       function fetch() {
-        return _ref5.apply(this, arguments);
+        return _ref13.apply(this, arguments);
       }
 
       return fetch;
     }()
   }, {
     key: "exists",
-    value: function exists() {
-      var _this2 = this;
+    value: function () {
+      var _ref14 = (0, _asyncToGenerator3.default)( /*#__PURE__*/_regenerator2.default.mark(function _callee14() {
+        var _this3 = this;
 
-      var redisPool = _redisPool2.default.getPool(this.redis);
-      var result = redisPool.ttlAsync("ConditionMap/" + this.applicationId).then(function (res) {
-        // TTL が -2 はキーがないとき。 -1 は無期限。0以上は有効期限(秒)
-        // したがって、キーがあって、正常な期限があること
-        return res !== -2 && res >= -1;
-      }).catch(function () {
-        throw new Error("Unable to retrieve a condition map key from redis for application " + _this2.applicationId);
-      });
-      return result;
-    }
+        var redisPool, result;
+        return _regenerator2.default.wrap(function _callee14$(_context14) {
+          while (1) {
+            switch (_context14.prev = _context14.next) {
+              case 0:
+                redisPool = _redisPool2.default.getPool(this.redis);
+                _context14.next = 3;
+                return redisPool.ttlAsync("ConditionMap/" + this.applicationId).then(function (res) {
+                  // TTL が -2 はキーがないとき。 -1 は無期限。0以上は有効期限(秒)
+                  // したがって、キーがあって、正常な期限があること
+                  return res !== -2 && res >= -1;
+                }).catch(function () {
+                  throw new Error("Unable to retrieve a condition map key from redis for application " + _this3.applicationId);
+                });
+
+              case 3:
+                result = _context14.sent;
+                return _context14.abrupt("return", result);
+
+              case 5:
+              case "end":
+                return _context14.stop();
+            }
+          }
+        }, _callee14, this);
+      }));
+
+      function exists() {
+        return _ref14.apply(this, arguments);
+      }
+
+      return exists;
+    }()
 
     /**
      * ConditionMap の TTL を設定する
@@ -356,15 +628,15 @@ var MapResource = function () {
   }, {
     key: "updateRedisTtl",
     value: function () {
-      var _ref6 = (0, _asyncToGenerator3.default)( /*#__PURE__*/_regenerator2.default.mark(function _callee6() {
+      var _ref15 = (0, _asyncToGenerator3.default)( /*#__PURE__*/_regenerator2.default.mark(function _callee15() {
         var ttl = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : MONTH;
         var redisPool, resultExpiration;
-        return _regenerator2.default.wrap(function _callee6$(_context6) {
+        return _regenerator2.default.wrap(function _callee15$(_context15) {
           while (1) {
-            switch (_context6.prev = _context6.next) {
+            switch (_context15.prev = _context15.next) {
               case 0:
                 redisPool = _redisPool2.default.getPool(this.redis);
-                _context6.next = 3;
+                _context15.next = 3;
                 return redisPool.expireAsync("ConditionMap/" + this.applicationId, ttl > 0 ? ttl : MONTH).then(function (res) {
                   return res;
                 }).catch(function (e) {
@@ -372,19 +644,19 @@ var MapResource = function () {
                 });
 
               case 3:
-                resultExpiration = _context6.sent;
-                return _context6.abrupt("return", resultExpiration === 1);
+                resultExpiration = _context15.sent;
+                return _context15.abrupt("return", resultExpiration === 1);
 
               case 5:
               case "end":
-                return _context6.stop();
+                return _context15.stop();
             }
           }
-        }, _callee6, this);
+        }, _callee15, this);
       }));
 
       function updateRedisTtl() {
-        return _ref6.apply(this, arguments);
+        return _ref15.apply(this, arguments);
       }
 
       return updateRedisTtl;
@@ -404,46 +676,50 @@ var MapResource = function () {
   }, {
     key: "store",
     value: function () {
-      var _ref7 = (0, _asyncToGenerator3.default)( /*#__PURE__*/_regenerator2.default.mark(function _callee7(mapJson) {
+      var _ref16 = (0, _asyncToGenerator3.default)( /*#__PURE__*/_regenerator2.default.mark(function _callee16(mapJson) {
         var ttl = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : MONTH;
         var redisPool, resultSet, resultExpiration;
-        return _regenerator2.default.wrap(function _callee7$(_context7) {
+        return _regenerator2.default.wrap(function _callee16$(_context16) {
           while (1) {
-            switch (_context7.prev = _context7.next) {
+            switch (_context16.prev = _context16.next) {
               case 0:
-                redisPool = _redisPool2.default.getPool(this.redis);
-                _context7.next = 3;
+                _context16.next = 2;
+                return _redisPool2.default.getPool(this.redis);
+
+              case 2:
+                redisPool = _context16.sent;
+                _context16.next = 5;
                 return redisPool.setAsync("ConditionMap/" + this.applicationId, mapJson).then(function (res) {
                   return res;
                 }).catch(function (e) {
                   throw e;
                 });
 
-              case 3:
-                resultSet = _context7.sent;
-                _context7.next = 6;
+              case 5:
+                resultSet = _context16.sent;
+                _context16.next = 8;
                 return redisPool.expireAsync("ConditionMap/" + this.applicationId, ttl > 0 ? ttl : MONTH).then(function (res) {
                   return res;
                 }).catch(function (e) {
                   throw e;
                 });
 
-              case 6:
-                resultExpiration = _context7.sent;
-                return _context7.abrupt("return", {
+              case 8:
+                resultExpiration = _context16.sent;
+                return _context16.abrupt("return", {
                   result: { store: resultSet === "OK", expiration: resultExpiration === 1 }
                 });
 
-              case 8:
+              case 10:
               case "end":
-                return _context7.stop();
+                return _context16.stop();
             }
           }
-        }, _callee7, this);
+        }, _callee16, this);
       }));
 
-      function store(_x2) {
-        return _ref7.apply(this, arguments);
+      function store(_x12) {
+        return _ref16.apply(this, arguments);
       }
 
       return store;
@@ -456,19 +732,35 @@ var MapResourceJson = function (_MapResource) {
   (0, _inherits3.default)(MapResourceJson, _MapResource);
 
   function MapResourceJson(conditionMapOptions) {
+    var _this5 = this;
+
     (0, _classCallCheck3.default)(this, MapResourceJson);
 
-    var _this3 = (0, _possibleConstructorReturn3.default)(this, (MapResourceJson.__proto__ || Object.getPrototypeOf(MapResourceJson)).call(this, conditionMapOptions));
+    var _this4 = (0, _possibleConstructorReturn3.default)(this, (MapResourceJson.__proto__ || Object.getPrototypeOf(MapResourceJson)).call(this, conditionMapOptions));
 
-    var map = _this3.sourceOptions.map;
+    var map = _this4.sourceOptions.map;
 
-    var extraSlotKeys = _this3.extraSlotKeys ? _this3.extraSlotKeys : [];
+    var extraSlotKeys = _this4.extraSlotKeys ? _this4.extraSlotKeys : [];
 
-    _this3.store(JSON.stringify({
-      conditionMap: JSON.parse(map),
-      extraSlotKeys: extraSlotKeys
+    _this4._init = (0, _asyncToGenerator3.default)( /*#__PURE__*/_regenerator2.default.mark(function _callee17() {
+      return _regenerator2.default.wrap(function _callee17$(_context17) {
+        while (1) {
+          switch (_context17.prev = _context17.next) {
+            case 0:
+              _context17.next = 2;
+              return _this4.store(JSON.stringify({
+                conditionMap: JSON.parse(map),
+                extraSlotKeys: extraSlotKeys
+              }));
+
+            case 2:
+            case "end":
+              return _context17.stop();
+          }
+        }
+      }, _callee17, _this5);
     }));
-    return _this3;
+    return _this4;
   }
 
   return MapResourceJson;
@@ -478,16 +770,35 @@ var MapResourceObject = function (_MapResource2) {
   (0, _inherits3.default)(MapResourceObject, _MapResource2);
 
   function MapResourceObject(conditionMapOptions) {
+    var _this7 = this;
+
     (0, _classCallCheck3.default)(this, MapResourceObject);
 
-    var _this4 = (0, _possibleConstructorReturn3.default)(this, (MapResourceObject.__proto__ || Object.getPrototypeOf(MapResourceObject)).call(this, conditionMapOptions));
+    var _this6 = (0, _possibleConstructorReturn3.default)(this, (MapResourceObject.__proto__ || Object.getPrototypeOf(MapResourceObject)).call(this, conditionMapOptions));
 
-    var map = _this4.sourceOptions.map;
+    var map = _this6.sourceOptions.map;
 
-    var extraSlotKeys = _this4.extraSlotKeys ? _this4.extraSlotKeys : [];
+    var extraSlotKeys = _this6.extraSlotKeys ? _this6.extraSlotKeys : [];
 
-    _this4.store(JSON.stringify({ conditionMap: map, extraSlotKeys: extraSlotKeys }));
-    return _this4;
+    _this6._init = (0, _asyncToGenerator3.default)( /*#__PURE__*/_regenerator2.default.mark(function _callee18() {
+      return _regenerator2.default.wrap(function _callee18$(_context18) {
+        while (1) {
+          switch (_context18.prev = _context18.next) {
+            case 0:
+              _context18.next = 2;
+              return _this6.store(JSON.stringify({
+                conditionMap: map,
+                extraSlotKeys: extraSlotKeys
+              }));
+
+            case 2:
+            case "end":
+              return _context18.stop();
+          }
+        }
+      }, _callee18, _this7);
+    }));
+    return _this6;
   }
 
   return MapResourceObject;
@@ -497,14 +808,33 @@ var MapResourceLocal = function (_MapResource3) {
   (0, _inherits3.default)(MapResourceLocal, _MapResource3);
 
   function MapResourceLocal(conditionMapOptions) {
+    var _this9 = this;
+
     (0, _classCallCheck3.default)(this, MapResourceLocal);
 
-    var _this5 = (0, _possibleConstructorReturn3.default)(this, (MapResourceLocal.__proto__ || Object.getPrototypeOf(MapResourceLocal)).call(this, conditionMapOptions));
+    var _this8 = (0, _possibleConstructorReturn3.default)(this, (MapResourceLocal.__proto__ || Object.getPrototypeOf(MapResourceLocal)).call(this, conditionMapOptions));
 
-    var extraSlotKeys = _this5.extraSlotKeys ? _this5.extraSlotKeys : [];
+    var extraSlotKeys = _this8.extraSlotKeys ? _this8.extraSlotKeys : [];
 
-    _this5.store(JSON.stringify({ conditionMap: TEST_MAP, extraSlotKeys: extraSlotKeys }));
-    return _this5;
+    _this8._init = (0, _asyncToGenerator3.default)( /*#__PURE__*/_regenerator2.default.mark(function _callee19() {
+      return _regenerator2.default.wrap(function _callee19$(_context19) {
+        while (1) {
+          switch (_context19.prev = _context19.next) {
+            case 0:
+              _context19.next = 2;
+              return _this8.store(JSON.stringify({
+                conditionMap: TEST_MAP,
+                extraSlotKeys: extraSlotKeys
+              }));
+
+            case 2:
+            case "end":
+              return _context19.stop();
+          }
+        }
+      }, _callee19, _this9);
+    }));
+    return _this8;
   }
 
   return MapResourceLocal;
@@ -514,43 +844,61 @@ var MapResourceRedis = function (_MapResource4) {
   (0, _inherits3.default)(MapResourceRedis, _MapResource4);
 
   function MapResourceRedis(conditionMapOptions) {
+    var _this11 = this;
+
     (0, _classCallCheck3.default)(this, MapResourceRedis);
 
-    // extraSlotKeysが指定されていたら同期を取る
-    var _this6 = (0, _possibleConstructorReturn3.default)(this, (MapResourceRedis.__proto__ || Object.getPrototypeOf(MapResourceRedis)).call(this, conditionMapOptions));
+    var _this10 = (0, _possibleConstructorReturn3.default)(this, (MapResourceRedis.__proto__ || Object.getPrototypeOf(MapResourceRedis)).call(this, conditionMapOptions));
 
-    if (_this6.extraSlotKeys) {
-      _this6._syncMap();
-    }
-    return _this6;
+    _this10._init = (0, _asyncToGenerator3.default)( /*#__PURE__*/_regenerator2.default.mark(function _callee20() {
+      return _regenerator2.default.wrap(function _callee20$(_context20) {
+        while (1) {
+          switch (_context20.prev = _context20.next) {
+            case 0:
+              if (!_this10.extraSlotKeys) {
+                _context20.next = 3;
+                break;
+              }
+
+              _context20.next = 3;
+              return _this10._syncMap();
+
+            case 3:
+            case "end":
+              return _context20.stop();
+          }
+        }
+      }, _callee20, _this11);
+    }));
+    return _this10;
   }
 
   (0, _createClass3.default)(MapResourceRedis, [{
     key: "_syncMap",
     value: function () {
-      var _ref8 = (0, _asyncToGenerator3.default)( /*#__PURE__*/_regenerator2.default.mark(function _callee8() {
-        return _regenerator2.default.wrap(function _callee8$(_context8) {
+      var _ref21 = (0, _asyncToGenerator3.default)( /*#__PURE__*/_regenerator2.default.mark(function _callee21() {
+        return _regenerator2.default.wrap(function _callee21$(_context21) {
           while (1) {
-            switch (_context8.prev = _context8.next) {
+            switch (_context21.prev = _context21.next) {
               case 0:
-                _context8.next = 2;
+                _context21.next = 2;
                 return this.fetch();
 
               case 2:
                 this.map.extraSlotKeys = this.extraSlotKeys;
-                _context8.next = 5;
+                _context21.next = 5;
                 return this.store(JSON.stringify(this.map));
 
               case 5:
               case "end":
-                return _context8.stop();
+                return _context21.stop();
             }
           }
-        }, _callee8, this);
+        }, _callee21, this);
       }));
 
       function _syncMap() {
-        return _ref8.apply(this, arguments);
+        return _ref21.apply(this, arguments);
       }
 
       return _syncMap;

--- a/dist/core/Context.js
+++ b/dist/core/Context.js
@@ -216,38 +216,59 @@ var Context = function () {
 
   }], [{
     key: "getOrInitial",
-    value: function getOrInitial(userId, redisPool, options) {
-      var extraSlotKeys = options.extraSlotKeys,
-          initialLifeSpan = options.initialLifeSpan,
-          holdUsedSlot = options.holdUsedSlot;
+    value: function () {
+      var _ref3 = (0, _asyncToGenerator3.default)( /*#__PURE__*/_regenerator2.default.mark(function _callee3(userId, redisPool, options) {
+        var extraSlotKeys, initialLifeSpan, holdUsedSlot;
+        return _regenerator2.default.wrap(function _callee3$(_context3) {
+          while (1) {
+            switch (_context3.prev = _context3.next) {
+              case 0:
+                extraSlotKeys = options.extraSlotKeys, initialLifeSpan = options.initialLifeSpan, holdUsedSlot = options.holdUsedSlot;
+                _context3.next = 3;
+                return redisPool.getAsync(userId).then(function (r) {
+                  if (!r) {
+                    console.log("new context generated ");
+                    return new Context(userId, redisPool, {
+                      extraSlotKeys: extraSlotKeys,
+                      initialLifeSpan: initialLifeSpan,
+                      holdUsedSlot: holdUsedSlot
+                    });
+                  }
 
-      return redisPool.getAsync(userId).then(function (r) {
-        if (!r) {
-          console.log("new context generated ");
-          return new Context(userId, redisPool, {
-            extraSlotKeys: extraSlotKeys,
-            initialLifeSpan: initialLifeSpan,
-            holdUsedSlot: holdUsedSlot
-          });
-        }
+                  var context = new Context(userId, redisPool, {
+                    extraSlotKeys: extraSlotKeys,
+                    initialLifeSpan: initialLifeSpan,
+                    holdUsedSlot: holdUsedSlot
+                  });
+                  var fromRedis = JSON.parse(r);
+                  context.body.merge(fromRedis.body);
+                  context.matchedCondition = fromRedis.matchedCondition;
+                  if (fromRedis.latestInput) {
+                    context.latestInput = fromRedis.latestInput;
+                  }
+                  if (fromRedis.extra) {
+                    context.extra = fromRedis.extra;
+                  }
+                  return context;
+                });
 
-        var context = new Context(userId, redisPool, {
-          extraSlotKeys: extraSlotKeys,
-          initialLifeSpan: initialLifeSpan,
-          holdUsedSlot: holdUsedSlot
-        });
-        var fromRedis = JSON.parse(r);
-        context.body.merge(fromRedis.body);
-        context.matchedCondition = fromRedis.matchedCondition;
-        if (fromRedis.latestInput) {
-          context.latestInput = fromRedis.latestInput;
-        }
-        if (fromRedis.extra) {
-          context.extra = fromRedis.extra;
-        }
-        return context;
-      });
-    }
+              case 3:
+                return _context3.abrupt("return", _context3.sent);
+
+              case 4:
+              case "end":
+                return _context3.stop();
+            }
+          }
+        }, _callee3, this);
+      }));
+
+      function getOrInitial(_x3, _x4, _x5) {
+        return _ref3.apply(this, arguments);
+      }
+
+      return getOrInitial;
+    }()
   }]);
   return Context;
 }();

--- a/dist/core/DialogueContextManager.js
+++ b/dist/core/DialogueContextManager.js
@@ -37,35 +37,60 @@ var _ConditionMap = require("./ConditionMap");
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 var DialogueContextManager = function () {
-  (0, _createClass3.default)(DialogueContextManager, null, [{
-    key: "getInstance",
+  function DialogueContextManager() {
+    (0, _classCallCheck3.default)(this, DialogueContextManager);
+  }
 
-    /**
-     * [Deprecated] DialogueContextManagerのインスタンスを取得する
-     *
-     * new DialogueContextManager(options) を使用してください
-     *
-     * @deprecated
-     * @param options
-     */
-    value: function getInstance(options /* see constructor */) {
-      return new DialogueContextManager(options);
-    }
-  }, {
-    key: "conditionMapExists",
+  (0, _createClass3.default)(DialogueContextManager, [{
+    key: "init",
     value: function () {
-      var _ref = (0, _asyncToGenerator3.default)( /*#__PURE__*/_regenerator2.default.mark(function _callee(applicationId, redisConfig) {
+      var _ref = (0, _asyncToGenerator3.default)( /*#__PURE__*/_regenerator2.default.mark(function _callee(options) {
+        var applicationId, conditionMap, redis, extraSlotKeys, initialLifeSpan, holdUsedSlot, verbose, condMap;
         return _regenerator2.default.wrap(function _callee$(_context) {
           while (1) {
             switch (_context.prev = _context.next) {
               case 0:
-                _context.next = 2;
-                return new _ConditionMap.ConditionMap(applicationId, DialogueContextManager._generateSourceOptionsForRedis(applicationId), redisConfig).mapExists();
+                applicationId = options.applicationId, conditionMap = options.conditionMap, redis = options.redis, extraSlotKeys = options.extraSlotKeys, initialLifeSpan = options.initialLifeSpan, holdUsedSlot = options.holdUsedSlot, verbose = options.verbose;
 
-              case 2:
-                return _context.abrupt("return", _context.sent);
+                if (applicationId) {
+                  _context.next = 3;
+                  break;
+                }
+
+                throw Error("DialogueContextManager#constructor: Valid applicationId required.");
 
               case 3:
+                this.applicationId = applicationId;
+
+                // 渡されてくるconditionMapが Falsy な値なら、
+                // Redisに保存されているConditionMapを使用する
+                // Truthy な値なら、その内容に基づいてConditionMapをつくる
+                condMap = null;
+
+                if (!conditionMap) {
+                  // it depends on valid applicationId and redisPool
+                  condMap = DialogueContextManager._generateSourceOptionsForRedis(applicationId);
+                } else {
+                  condMap = conditionMap;
+                }
+                // ConditionMapにextraSlotKeysを渡す
+                condMap.extraSlotKeys = extraSlotKeys;
+
+                _context.next = 9;
+                return _ConditionMap.ConditionMap.getInstance(this.applicationId, condMap, redis);
+
+              case 9:
+                this.ruleMap = _context.sent;
+
+
+                this.redis = redis;
+
+                this.extraSlotKeys = extraSlotKeys;
+                this.holdUsedSlot = holdUsedSlot;
+                this.initialLifeSpan = initialLifeSpan;
+                this.verbose = verbose;
+
+              case 15:
               case "end":
                 return _context.stop();
             }
@@ -73,64 +98,13 @@ var DialogueContextManager = function () {
         }, _callee, this);
       }));
 
-      function conditionMapExists(_x, _x2) {
+      function init(_x) {
         return _ref.apply(this, arguments);
       }
 
-      return conditionMapExists;
+      return init;
     }()
   }, {
-    key: "_generateSourceOptionsForRedis",
-    value: function _generateSourceOptionsForRedis(applicationId) {
-      return {
-        source: "redis",
-        sourceOptions: {
-          applicationId: applicationId
-        }
-      };
-    }
-  }]);
-
-  function DialogueContextManager(options) {
-    (0, _classCallCheck3.default)(this, DialogueContextManager);
-    var applicationId = options.applicationId,
-        conditionMap = options.conditionMap,
-        redis = options.redis,
-        extraSlotKeys = options.extraSlotKeys,
-        initialLifeSpan = options.initialLifeSpan,
-        holdUsedSlot = options.holdUsedSlot,
-        verbose = options.verbose;
-
-
-    if (!applicationId) {
-      throw Error("DialogueContextManager#constructor: Valid applicationId required.");
-    }
-    this.applicationId = applicationId;
-
-    // 渡されてくるconditionMapが Falsy な値なら、
-    // Redisに保存されているConditionMapを使用する
-    // Truthy な値なら、その内容に基づいてConditionMapをつくる
-    var condMap = null;
-    if (!conditionMap) {
-      // it depends on valid applicationId and redisPool
-      condMap = DialogueContextManager._generateSourceOptionsForRedis(applicationId);
-    } else {
-      condMap = conditionMap;
-    }
-    // ConditionMapにextraSlotKeysを渡す
-    condMap.extraSlotKeys = extraSlotKeys;
-
-    this.ruleMap = new _ConditionMap.ConditionMap(this.applicationId, condMap, redis);
-
-    this.redis = redis;
-
-    this.extraSlotKeys = extraSlotKeys;
-    this.holdUsedSlot = holdUsedSlot;
-    this.initialLifeSpan = initialLifeSpan;
-    this.verbose = verbose;
-  }
-
-  (0, _createClass3.default)(DialogueContextManager, [{
     key: "vLog",
     value: function vLog(text) {
       if (!this.verbose) {
@@ -228,7 +202,7 @@ var DialogueContextManager = function () {
         }, _callee2, this, [[1, 28]]);
       }));
 
-      function getNewContext(_x3, _x4) {
+      function getNewContext(_x2, _x3) {
         return _ref2.apply(this, arguments);
       }
 
@@ -260,6 +234,82 @@ var DialogueContextManager = function () {
         }
       });
       return errors;
+    }
+  }], [{
+    key: "getInstance",
+
+    /**
+     * DialogueContextManagerのインスタンスを取得する
+     *
+     * @param options
+     */
+    value: function () {
+      var _ref3 = (0, _asyncToGenerator3.default)( /*#__PURE__*/_regenerator2.default.mark(function _callee3(options /* see constructor */) {
+        var dcm;
+        return _regenerator2.default.wrap(function _callee3$(_context3) {
+          while (1) {
+            switch (_context3.prev = _context3.next) {
+              case 0:
+                dcm = new DialogueContextManager();
+                _context3.next = 3;
+                return dcm.init(options);
+
+              case 3:
+                return _context3.abrupt("return", dcm);
+
+              case 4:
+              case "end":
+                return _context3.stop();
+            }
+          }
+        }, _callee3, this);
+      }));
+
+      function getInstance(_x4) {
+        return _ref3.apply(this, arguments);
+      }
+
+      return getInstance;
+    }()
+  }, {
+    key: "conditionMapExists",
+    value: function () {
+      var _ref4 = (0, _asyncToGenerator3.default)( /*#__PURE__*/_regenerator2.default.mark(function _callee4(applicationId, redisConfig) {
+        var cm;
+        return _regenerator2.default.wrap(function _callee4$(_context4) {
+          while (1) {
+            switch (_context4.prev = _context4.next) {
+              case 0:
+                _context4.next = 2;
+                return _ConditionMap.ConditionMap.getInstance(applicationId, DialogueContextManager._generateSourceOptionsForRedis(applicationId), redisConfig);
+
+              case 2:
+                cm = _context4.sent;
+                return _context4.abrupt("return", cm.mapExists());
+
+              case 4:
+              case "end":
+                return _context4.stop();
+            }
+          }
+        }, _callee4, this);
+      }));
+
+      function conditionMapExists(_x5, _x6) {
+        return _ref4.apply(this, arguments);
+      }
+
+      return conditionMapExists;
+    }()
+  }, {
+    key: "_generateSourceOptionsForRedis",
+    value: function _generateSourceOptionsForRedis(applicationId) {
+      return {
+        source: "redis",
+        sourceOptions: {
+          applicationId: applicationId
+        }
+      };
     }
   }]);
   return DialogueContextManager;

--- a/example/package.json
+++ b/example/package.json
@@ -4,6 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
+    "start": "node start.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "",

--- a/example/start.js
+++ b/example/start.js
@@ -27,22 +27,21 @@ const options = {
 };
 
 
-function main() {
-  const contextManager = new DialogueContextManager(options);
-  contextManager.getNewContext("testuser", {isAvailable: true, body: {slot1: {keyword: "foo"}}})
-    .then((context) => {
+async function main() {
+  DialogueContextManager.getInstance(options).then(contextManager => {
+    contextManager.getNewContext("testuser", {isAvailable: true, body: {slot1: {keyword: "foo"}}})
+      .then((context) => {
+        console.log( context.matchedCondition );
+        console.log( context.body );
+        console.log( context.extra );
 
-      console.log( context.matchedCondition );
-      console.log( context.body );
-      console.log( context.extra );
+        context.extra.hoge = "1";
+        context.persist();
 
-      context.extra.hoge = "1";
-      context.persist();
-
-    }).catch(( error )=>{
-      console.log ( error );
-    });
-
+      }).catch(( error )=>{
+        console.log ( error );
+      });
+  });
 };
 
 main();

--- a/lib/core/ConditionMap.js
+++ b/lib/core/ConditionMap.js
@@ -4,13 +4,15 @@ const rp = require("request-promise");
 
 export class ConditionMap {
   map = null;
-  static getInstance(applicationId, conditionMapOptions, redisConfig) {
-    return new ConditionMap(applicationId, conditionMapOptions, redisConfig);
+  static async getInstance(applicationId, conditionMapOptions, redisConfig) {
+    const cm = new ConditionMap();
+    await cm._init(applicationId, conditionMapOptions, redisConfig);
+    return cm;
   }
 
   //TODO: BluebirdのRedisでキーの存在チェックできる？
 
-  constructor(applicationId, conditionMapOptions, redisConfig) {
+  async _init(applicationId, conditionMapOptions, redisConfig) {
     if (
       applicationId === undefined ||
       applicationId === null ||
@@ -22,17 +24,25 @@ export class ConditionMap {
     conditionMapOptions.applicationId = applicationId;
     conditionMapOptions.redis = redisConfig;
 
-    this.source = this._sourceSelector(conditionMapOptions);
+    this.source = await this._sourceSelector(conditionMapOptions);
     this.fetchForEachRequest = conditionMapOptions.fetchForEachRequest;
   }
 
-  _sourceSelector(conditionMapOptions) {
+  async _sourceSelector(conditionMapOptions) {
     const source = conditionMapOptions.source;
-    if (source === "json") return new MapResourceJson(conditionMapOptions);
-    if (source === "object") return new MapResourceObject(conditionMapOptions);
-    if (source === "redis") return new MapResourceRedis(conditionMapOptions);
+
+    if (source === "json")
+      return await MapResource.initializeWithJSON(conditionMapOptions);
+
+    if (source === "object")
+      return await MapResource.initializeWithObject(conditionMapOptions);
+
+    if (source === "redis")
+      return await MapResource.initializeWithRedis(conditionMapOptions);
+
     if (source === "testLocal")
       return new MapResourceLocal(conditionMapOptions);
+
     throw new Error(`No valid source type specified: ${source}`);
   }
 
@@ -73,6 +83,24 @@ export class ConditionMap {
 }
 
 class MapResource {
+  static async initializeWithJSON(conditionMapOptions) {
+    const res = new MapResourceJson(conditionMapOptions);
+    await res.init();
+    return res;
+  }
+
+  static async initializeWithObject(conditionMapOptions) {
+    const res = new MapResourceObject(conditionMapOptions);
+    await res.init();
+    return res;
+  }
+
+  static async initializeWithRedis(conditionMapOptions) {
+    const res = new MapResourceRedis(conditionMapOptions);
+    await res.init();
+    return res;
+  }
+
   constructor(conditionMapOptions) {
     const {
       applicationId,
@@ -88,6 +116,12 @@ class MapResource {
     if (!(extraSlotKeys === undefined && extraSlotKeys instanceof Array)) {
       this.extraSlotKeys = extraSlotKeys;
     }
+
+    this._init = async () => {};
+  }
+
+  async init() {
+    await this._init();
   }
 
   /**
@@ -115,7 +149,7 @@ class MapResource {
         );
       });
 
-    if (map instanceof Array) {
+    if (Array.isArray(map)) {
       // 取得したものが配列なら extraSlotKeys 情報が付加されていない ConditionMap とみなす
       map = { conditionMap: map, extraSlotKeys: [] };
       //TODO: map の内容から extraSlotKeysを推論させる？
@@ -144,9 +178,9 @@ class MapResource {
     return map;
   }
 
-  exists() {
+  async exists() {
     const redisPool = RedisPool.getPool(this.redis);
-    const result = redisPool
+    const result = await redisPool
       .ttlAsync(`ConditionMap/${this.applicationId}`)
       .then(res => {
         // TTL が -2 はキーがないとき。 -1 は無期限。0以上は有効期限(秒)
@@ -192,7 +226,7 @@ class MapResource {
    * @returns {Promise<{result: {store: boolean, expiration: boolean}}>} データの保存と有効期限のセットの成否がbooleanで表現される
    */
   async store(mapJson, ttl = MONTH) {
-    const redisPool = RedisPool.getPool(this.redis);
+    const redisPool = await RedisPool.getPool(this.redis);
     const resultSet = await redisPool
       .setAsync(`ConditionMap/${this.applicationId}`, mapJson)
       .then(res => {
@@ -223,12 +257,14 @@ class MapResourceJson extends MapResource {
     const { map } = this.sourceOptions;
     const extraSlotKeys = this.extraSlotKeys ? this.extraSlotKeys : [];
 
-    this.store(
-      JSON.stringify({
-        conditionMap: JSON.parse(map),
-        extraSlotKeys: extraSlotKeys,
-      }),
-    );
+    this._init = async () => {
+      await this.store(
+        JSON.stringify({
+          conditionMap: JSON.parse(map),
+          extraSlotKeys: extraSlotKeys,
+        }),
+      );
+    };
   }
 }
 
@@ -238,9 +274,14 @@ class MapResourceObject extends MapResource {
     const { map } = this.sourceOptions;
     const extraSlotKeys = this.extraSlotKeys ? this.extraSlotKeys : [];
 
-    this.store(
-      JSON.stringify({ conditionMap: map, extraSlotKeys: extraSlotKeys }),
-    );
+    this._init = async () => {
+      await this.store(
+        JSON.stringify({
+          conditionMap: map,
+          extraSlotKeys: extraSlotKeys,
+        }),
+      );
+    };
   }
 }
 
@@ -249,19 +290,26 @@ class MapResourceLocal extends MapResource {
     super(conditionMapOptions);
     const extraSlotKeys = this.extraSlotKeys ? this.extraSlotKeys : [];
 
-    this.store(
-      JSON.stringify({ conditionMap: TEST_MAP, extraSlotKeys: extraSlotKeys }),
-    );
+    this._init = async () => {
+      await this.store(
+        JSON.stringify({
+          conditionMap: TEST_MAP,
+          extraSlotKeys: extraSlotKeys,
+        }),
+      );
+    };
   }
 }
 
 class MapResourceRedis extends MapResource {
   constructor(conditionMapOptions) {
     super(conditionMapOptions);
-    // extraSlotKeysが指定されていたら同期を取る
-    if (this.extraSlotKeys) {
-      this._syncMap();
-    }
+    this._init = async () => {
+      // extraSlotKeysが指定されていたら同期を取る
+      if (this.extraSlotKeys) {
+        await this._syncMap();
+      }
+    };
   }
 
   async _syncMap() {

--- a/lib/core/Context.js
+++ b/lib/core/Context.js
@@ -125,9 +125,9 @@ export default class Context {
    * @param options
    * @returns {*}
    */
-  static getOrInitial(userId, redisPool, options) {
+  static async getOrInitial(userId, redisPool, options) {
     const { extraSlotKeys, initialLifeSpan, holdUsedSlot } = options;
-    return redisPool.getAsync(userId).then(r => {
+    return await redisPool.getAsync(userId).then(r => {
       if (!r) {
         console.log("new context generated ");
         return new Context(userId, redisPool, {

--- a/lib/core/DialogueContextManager.js
+++ b/lib/core/DialogueContextManager.js
@@ -5,23 +5,23 @@ import { ConditionMap } from "./ConditionMap";
 
 export default class DialogueContextManager {
   /**
-   * [Deprecated] DialogueContextManagerのインスタンスを取得する
+   * DialogueContextManagerのインスタンスを取得する
    *
-   * new DialogueContextManager(options) を使用してください
-   *
-   * @deprecated
    * @param options
    */
-  static getInstance(options /* see constructor */) {
-    return new DialogueContextManager(options);
+  static async getInstance(options /* see constructor */) {
+    const dcm = new DialogueContextManager();
+    await dcm.init(options);
+    return dcm;
   }
 
   static async conditionMapExists(applicationId, redisConfig) {
-    return await new ConditionMap(
+    const cm = await ConditionMap.getInstance(
       applicationId,
       DialogueContextManager._generateSourceOptionsForRedis(applicationId),
       redisConfig,
-    ).mapExists();
+    );
+    return cm.mapExists();
   }
 
   static _generateSourceOptionsForRedis(applicationId) {
@@ -33,7 +33,7 @@ export default class DialogueContextManager {
     };
   }
 
-  constructor(options) {
+  async init(options) {
     const {
       applicationId,
       conditionMap,
@@ -66,7 +66,11 @@ export default class DialogueContextManager {
     // ConditionMapにextraSlotKeysを渡す
     condMap.extraSlotKeys = extraSlotKeys;
 
-    this.ruleMap = new ConditionMap(this.applicationId, condMap, redis);
+    this.ruleMap = await ConditionMap.getInstance(
+      this.applicationId,
+      condMap,
+      redis,
+    );
 
     this.redis = redis;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -95,9 +95,9 @@
           }
         },
         "supports-color": {
-          "version": "5.4.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
-          "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
           "dev": true,
           "requires": {
             "has-flag": "^3.0.0"
@@ -159,9 +159,9 @@
           }
         },
         "globals": {
-          "version": "11.5.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-11.5.0.tgz",
-          "integrity": "sha512-hYyf+kI8dm3nORsiiXUQigOU62hDLfJ9G01uyGMxhc6BKsircrUhC4uJPQPUSuq2GrTmiiEt7ewxlMdBewfmKQ==",
+          "version": "11.7.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-11.7.0.tgz",
+          "integrity": "sha512-K8BNSPySfeShBQXsahYB/AbbWruVOTyVpgoIDnl8odPpeSfP2J5QO2oLFFdl2j7GfDCtZj2bMKar2T49itTPCg==",
           "dev": true
         }
       }
@@ -318,9 +318,12 @@
       "dev": true
     },
     "asn1": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-      "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
+      "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+      "requires": {
+        "safer-buffer": "~2.1.0"
+      }
     },
     "assert-plus": {
       "version": "1.0.0",
@@ -350,9 +353,9 @@
       "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
     },
     "aws4": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.7.0.tgz",
-      "integrity": "sha512-32NDda82rhwD9/JBCCkB+MRYDp0oSvlo2IL6rQWA10PQi7tDUM3eqMSltXmY+Oyl/7N3P3qNtAlv7X0d9bI28w=="
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
+      "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
     },
     "babel-cli": {
       "version": "6.26.0",
@@ -423,16 +426,16 @@
       }
     },
     "babel-eslint": {
-      "version": "8.2.3",
-      "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-8.2.3.tgz",
-      "integrity": "sha512-0HeSTtaXg/Em7FCUWxwOT+KeFSO1O7LuRuzhk7g+1BjwdlQGlHq4OyMi3GqGxrNfEq8jEi6Hmt5ylEQUhurgiQ==",
+      "version": "8.2.6",
+      "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-8.2.6.tgz",
+      "integrity": "sha512-aCdHjhzcILdP8c9lej7hvXKvQieyRt20SF102SIGyY4cUIiw6UaAtK4j2o3dXX74jEmy0TJ0CEhv4fTIM3SzcA==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "7.0.0-beta.44",
         "@babel/traverse": "7.0.0-beta.44",
         "@babel/types": "7.0.0-beta.44",
         "babylon": "7.0.0-beta.44",
-        "eslint-scope": "~3.7.1",
+        "eslint-scope": "3.7.1",
         "eslint-visitor-keys": "^1.0.0"
       },
       "dependencies": {
@@ -1247,9 +1250,9 @@
       "dev": true
     },
     "bcrypt-pbkdf": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
-      "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
       "optional": true,
       "requires": {
         "tweetnacl": "^0.14.3"
@@ -1262,9 +1265,9 @@
       "dev": true
     },
     "bluebird": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
-      "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA=="
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.2.tgz",
+      "integrity": "sha512-dhHTWMI7kMx5whMQntl7Vr9C6BvV10lFXDAasnqnrMYhXVCzzk6IO9Fo2L75jXHT07WrOngL1WDXOp+yYS91Yg=="
     },
     "boolify": {
       "version": "1.0.1",
@@ -1354,6 +1357,15 @@
         "get-func-name": "^2.0.0",
         "pathval": "^1.0.0",
         "type-detect": "^4.0.0"
+      }
+    },
+    "chai-as-promised": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/chai-as-promised/-/chai-as-promised-7.1.1.tgz",
+      "integrity": "sha512-azL6xMoi+uxu6z4rhWQ1jbdUhOMhis2PvscD/xjLqNMkv3BPPp2JyyuTHOrf9BOosGpNQ11v6BKv/g57RXbiaA==",
+      "dev": true,
+      "requires": {
+        "check-error": "^1.0.2"
       }
     },
     "chalk": {
@@ -1516,12 +1528,11 @@
       }
     },
     "config": {
-      "version": "1.30.0",
-      "resolved": "https://registry.npmjs.org/config/-/config-1.30.0.tgz",
-      "integrity": "sha1-HWCp81NIoTwXV5jThOgaWhbDum4=",
+      "version": "1.31.0",
+      "resolved": "https://registry.npmjs.org/config/-/config-1.31.0.tgz",
+      "integrity": "sha512-Ep/l9Rd1J9IPueztJfpbOqVzuKHQh4ZODMNt9xqTYdBBNRXbV4oTu34kCkkfdRVcDq0ohtpaeXGgb+c0LQxFRA==",
       "requires": {
-        "json5": "0.4.0",
-        "os-homedir": "1.0.2"
+        "json5": "^1.0.1"
       }
     },
     "convert-source-map": {
@@ -1644,12 +1655,13 @@
       "integrity": "sha1-ED01J/0xUo9AGIEwyEHv3XgmTlw="
     },
     "ecc-jsbn": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
-      "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+      "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
       "optional": true,
       "requires": {
-        "jsbn": "~0.1.0"
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.1.0"
       }
     },
     "escape-string-regexp": {
@@ -1765,18 +1777,18 @@
       }
     },
     "eslint-config-prettier": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-2.9.0.tgz",
-      "integrity": "sha512-ag8YEyBXsm3nmOv1Hz991VtNNDMRa+MNy8cY47Pl4bw6iuzqKbJajXdqUpiw13STdLLrznxgm1hj9NhxeOYq0A==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-2.10.0.tgz",
+      "integrity": "sha512-Mhl90VLucfBuhmcWBgbUNtgBiK955iCDK1+aHAz7QfDQF6wuzWZ6JjihZ3ejJoGlJWIuko7xLqNm8BA5uenKhA==",
       "dev": true,
       "requires": {
         "get-stdin": "^5.0.1"
       }
     },
     "eslint-plugin-prettier": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-2.6.0.tgz",
-      "integrity": "sha512-floiaI4F7hRkTrFe8V2ItOK97QYrX75DjmdzmVITZoAP6Cn06oEDPQRsO6MlHEP/u2SxI3xQ52Kpjw6j5WGfeQ==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-2.6.2.tgz",
+      "integrity": "sha512-tGek5clmW5swrAx1mdPYM8oThrBE83ePh7LeseZHBWfHVGrHPhKn7Y5zgRMbU/9D5Td9K4CEmUPjGxA7iw98Og==",
       "dev": true,
       "requires": {
         "fast-diff": "^1.1.1",
@@ -1887,9 +1899,9 @@
       }
     },
     "extend": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
-      "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
     },
     "external-editor": {
       "version": "2.2.0",
@@ -2681,11 +2693,11 @@
       "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
     },
     "har-validator": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
-      "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.0.tgz",
+      "integrity": "sha512-+qnmNjI4OfH2ipQ9VQOw23bBd/ibtfbVdK2fYbY4acTDqKTW/YDp9McimZdDbG8iV9fZizUqQMD5xvriB146TA==",
       "requires": {
-        "ajv": "^5.1.0",
+        "ajv": "^5.3.0",
         "har-schema": "^2.0.0"
       }
     },
@@ -3069,9 +3081,19 @@
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
     },
     "json5": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz",
-      "integrity": "sha1-BUNS5MTIDIbAkjh31EneF2pzLI0="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+      "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+      "requires": {
+        "minimist": "^1.2.0"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+        }
+      }
     },
     "jsprim": {
       "version": "1.4.1",
@@ -3299,16 +3321,16 @@
       }
     },
     "mime-db": {
-      "version": "1.33.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
-      "integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ=="
+      "version": "1.36.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.36.0.tgz",
+      "integrity": "sha512-L+xvyD9MkoYMXb1jAmzI/lWYAxAMCPvIBSWur0PZ5nOf5euahRLVqH//FKW9mWp2lkqUgYiXPgkzfMUFi4zVDw=="
     },
     "mime-types": {
-      "version": "2.1.18",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
-      "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
+      "version": "2.1.20",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.20.tgz",
+      "integrity": "sha512-HrkrPaP9vGuWbLK1B1FfgAkbqNjIuy4eHlIYnFi7kamZyLLrGlo2mpcx0bBmNpKqBtYtAfGbodDddIgddSJC2A==",
       "requires": {
-        "mime-db": "~1.33.0"
+        "mime-db": "~1.36.0"
       }
     },
     "mimic-fn": {
@@ -3381,14 +3403,14 @@
       }
     },
     "moment": {
-      "version": "2.22.1",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.22.1.tgz",
-      "integrity": "sha512-shJkRTSebXvsVqk56I+lkb2latjBs8I+pc2TzWc545y2iFnSjm7Wg0QMh+ZWcdSLQyGEau5jI8ocnmkyTgr9YQ=="
+      "version": "2.22.2",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.22.2.tgz",
+      "integrity": "sha1-PCV/mDn8DpP/UxSWMiOeuQeD/2Y="
     },
     "moment-timezone": {
-      "version": "0.5.17",
-      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.17.tgz",
-      "integrity": "sha512-Y/JpVEWIOA9Gho4vO15MTnW1FCmHi3ypprrkUaxsZ1TKg3uqC8q/qMBjTddkHoiwwZN3qvZSr4zJP7x9V3LpXA==",
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.21.tgz",
+      "integrity": "sha512-j96bAh4otsgj3lKydm3K7kdtA3iKf2m6MY2iSYCzCm5a1zmHo1g+aK3068dDEeocLZQIS9kU8bsdQHLqEvgW0A==",
       "requires": {
         "moment": ">= 2.9.0"
       }
@@ -3464,9 +3486,9 @@
       "dev": true
     },
     "oauth-sign": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-      "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
     },
     "object-assign": {
       "version": "4.1.1",
@@ -3519,7 +3541,8 @@
     "os-homedir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
+      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+      "dev": true
     },
     "os-locale": {
       "version": "2.1.0",
@@ -3683,9 +3706,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "1.13.3",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.13.3.tgz",
-      "integrity": "sha512-CIWJNU+cFFdeA0GJSzzFkxiq2WuMvWZMlz6cV/EXhPlRnI3esSFMh+lNmyZ8z/X8O8C1U60Sc8puXALj4/WmZw==",
+      "version": "1.14.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.14.2.tgz",
+      "integrity": "sha512-McHPg0n1pIke+A/4VcaS2en+pTNjy4xF+Uuq86u/5dyDO59/TtFZtQ708QIRkEZ3qwKz3GVkVa6mpxK/CpB8Rg==",
       "dev": true
     },
     "prettier-eslint": {
@@ -3821,6 +3844,11 @@
       "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
       "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
       "dev": true
+    },
+    "psl": {
+      "version": "1.1.29",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.29.tgz",
+      "integrity": "sha512-AeUmQ0oLN02flVHXWh9sSJF7mcdFq0ppid/JkErufc3hGIV/AMa8Fo9VgDo/cT2jFdOWoFvHp90qqBH54W+gjQ=="
     },
     "punycode": {
       "version": "1.4.1",
@@ -4031,30 +4059,41 @@
       }
     },
     "request": {
-      "version": "2.87.0",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.87.0.tgz",
-      "integrity": "sha512-fcogkm7Az5bsS6Sl0sibkbhcKsnyon/jV1kF3ajGmF0c8HrttdKTPRT9hieOaQHA5HEq6r8OyWOo/o781C1tNw==",
+      "version": "2.88.0",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
+      "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
       "requires": {
         "aws-sign2": "~0.7.0",
-        "aws4": "^1.6.0",
+        "aws4": "^1.8.0",
         "caseless": "~0.12.0",
-        "combined-stream": "~1.0.5",
-        "extend": "~3.0.1",
+        "combined-stream": "~1.0.6",
+        "extend": "~3.0.2",
         "forever-agent": "~0.6.1",
-        "form-data": "~2.3.1",
-        "har-validator": "~5.0.3",
+        "form-data": "~2.3.2",
+        "har-validator": "~5.1.0",
         "http-signature": "~1.2.0",
         "is-typedarray": "~1.0.0",
         "isstream": "~0.1.2",
         "json-stringify-safe": "~5.0.1",
-        "mime-types": "~2.1.17",
-        "oauth-sign": "~0.8.2",
+        "mime-types": "~2.1.19",
+        "oauth-sign": "~0.9.0",
         "performance-now": "^2.1.0",
-        "qs": "~6.5.1",
-        "safe-buffer": "^5.1.1",
-        "tough-cookie": "~2.3.3",
+        "qs": "~6.5.2",
+        "safe-buffer": "^5.1.2",
+        "tough-cookie": "~2.4.3",
         "tunnel-agent": "^0.6.0",
-        "uuid": "^3.1.0"
+        "uuid": "^3.3.2"
+      },
+      "dependencies": {
+        "tough-cookie": {
+          "version": "2.4.3",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
+          "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
+          "requires": {
+            "psl": "^1.1.24",
+            "punycode": "^1.4.1"
+          }
+        }
       }
     },
     "request-promise": {
@@ -4176,8 +4215,7 @@
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "samsam": {
       "version": "1.3.0",
@@ -4219,9 +4257,9 @@
       "dev": true
     },
     "should": {
-      "version": "13.2.1",
-      "resolved": "https://registry.npmjs.org/should/-/should-13.2.1.tgz",
-      "integrity": "sha512-l+/NwEMO+DcstsHEwPHRHzC9j4UOE3VQwJGcMWSsD/vqpqHbnQ+1iSHy64Ihmmjx1uiRPD9pFadTSc3MJtXAgw==",
+      "version": "13.2.3",
+      "resolved": "https://registry.npmjs.org/should/-/should-13.2.3.tgz",
+      "integrity": "sha512-ggLesLtu2xp+ZxI+ysJTmNjh2U0TsC+rQ/pfED9bUZZ4DKefP27D+7YJVVTvKsmjLpIi9jAa7itwDGkDDmt1GQ==",
       "dev": true,
       "requires": {
         "should-equal": "^2.0.0",
@@ -4310,9 +4348,9 @@
       }
     },
     "sinon-chai": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/sinon-chai/-/sinon-chai-3.1.0.tgz",
-      "integrity": "sha512-gKcpH0GpDwEDWq6DXzdKf2PCvK4MgB2x6w1hSaNVQKnGF7vDY+uM7RK15pHqRuleypDKFpLUVDPTvlpyBVV1Mw==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/sinon-chai/-/sinon-chai-3.2.0.tgz",
+      "integrity": "sha512-Z72B4a0l0IQe5uWi9yzcqX/Ml6K9e1Hp03NmkjJnRG3gDsKTX7KvLFZsVUmCaz0eqeXLLK089mwTsP1P1W+DUQ==",
       "dev": true
     },
     "slash": {
@@ -4352,9 +4390,9 @@
       "dev": true
     },
     "sshpk": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.1.tgz",
-      "integrity": "sha1-Ew9Zde3a2WPx1W+SuaxsUfqfg+s=",
+      "version": "1.14.2",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.2.tgz",
+      "integrity": "sha1-xvxhZIo9nE52T9P8306hBeSSupg=",
       "requires": {
         "asn1": "~0.2.3",
         "assert-plus": "^1.0.0",
@@ -4363,6 +4401,7 @@
         "ecc-jsbn": "~0.1.1",
         "getpass": "^0.1.1",
         "jsbn": "~0.1.0",
+        "safer-buffer": "^2.0.2",
         "tweetnacl": "~0.14.0"
       }
     },
@@ -4606,9 +4645,9 @@
       "dev": true
     },
     "uuid": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
-      "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA=="
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
     },
     "v8flags": {
       "version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "babel-preset-stage-3": "^6.24.1",
     "babel-watch": "^2.0.7",
     "chai": "^4.1.2",
+    "chai-as-promised": "^7.1.1",
     "eslint": "^4.19.1",
     "eslint-config-prettier": "^2.9.0",
     "eslint-plugin-prettier": "^2.6.0",

--- a/test/core/ConditionMap.spec.js
+++ b/test/core/ConditionMap.spec.js
@@ -1,10 +1,14 @@
 import * as sinon from "sinon";
-import {expect} from "chai"
+import chai from "chai";
+import chaiAsPromised from "chai-as-promised";
 import fs from "fs";
-
 
 import {ConditionMap} from "@/core/ConditionMap";
 import * as config from "config";
+
+chai.use(chaiAsPromised);
+const should = chai.should();
+const { expect, assert } = chai;
 
 describe("ConditionMap", function () {
   beforeEach(() => {
@@ -15,7 +19,7 @@ describe("ConditionMap", function () {
     context("get", function () {
       it("直接JSONでデータを流し込む", async () => {
         let jsonfile = fs.readFileSync("./test/fixtures/knowledge.json");
-        const ruleMap = new ConditionMap(
+        const ruleMap = await ConditionMap.getInstance(
           `dummyApplicationId100${new Date().getTime()}`,
           {
             source: "json",
@@ -36,7 +40,7 @@ describe("ConditionMap", function () {
     context("get", function () {
       it("直接Objectでデータを流し込む", async () => {
         let jsonfile = fs.readFileSync("./test/fixtures/knowledge.json");
-        const ruleMap = new ConditionMap(
+        const ruleMap = await ConditionMap.getInstance(
           `dummyApplicationId100${new Date().getTime()}`,
           {
             source: "object",
@@ -55,7 +59,7 @@ describe("ConditionMap", function () {
     context("get - applicationId", function () {
       it("applicationIdがnullのときErrorがThrow", async () => {
         let jsonfile = fs.readFileSync("./test/fixtures/knowledge.json");
-        expect(() => new ConditionMap(
+        expect(ConditionMap.getInstance(
           null,
           {
             source: "object",
@@ -64,13 +68,13 @@ describe("ConditionMap", function () {
             },
             fetchForEachRequest: false,
           },
-          config.redis)).to.throw(Error);
+          config.redis)).to.be.rejectedWith(Error);
       }).timeout(5000);
     });
     context("get - applicationId", function () {
       it("applicationIdが空のときErrorがThrow", async () => {
         let jsonfile = fs.readFileSync("./test/fixtures/knowledge.json");
-        expect(() => new ConditionMap(
+        expect(ConditionMap.getInstance(
           "",
           {
             source: "object",
@@ -79,13 +83,13 @@ describe("ConditionMap", function () {
             },
             fetchForEachRequest: false,
           },
-          config.redis)).to.throw(Error);
+          config.redis)).to.be.rejectedWith(Error);
       }).timeout(5000);
     });
     context("get - applicationId", function () {
       it("applicationIdがundefinedのときErrorがThrow", async () => {
         let jsonfile = fs.readFileSync("./test/fixtures/knowledge.json");
-        expect(() => new ConditionMap(
+        expect(ConditionMap.getInstance(
           undefined,
           {
             source: "object",
@@ -94,7 +98,7 @@ describe("ConditionMap", function () {
             },
             fetchForEachRequest: false,
           },
-          config.redis)).to.throw(Error);
+          config.redis)).to.be.rejectedWith(Error);
       }).timeout(5000);
     });
 
@@ -103,7 +107,7 @@ describe("ConditionMap", function () {
   context("source=redis", function () {
 
     it("Redisから存在しないデータを読んで、ErrorがThrowされる", async () => {
-      const ruleMap = new ConditionMap(
+      const ruleMap = await ConditionMap.getInstance(
         `dummyApplicationId100${new Date().getTime()}`,
         {
           source: "redis",
@@ -111,17 +115,11 @@ describe("ConditionMap", function () {
           fetchForEachRequest: false,
         },
         config.redis);
-
-      try {
-        const map = await ruleMap.get();
-        expect.fail("ここはこないはず");
-      } catch (e) {
-        expect(e).instanceof(Error)
-      }
+      expect(ruleMap.get()).to.be.rejectedWith(Error);
     }).timeout(5000);
 
     it("Redisにデータの存在を確認したとき、存在しないときはFalseが返ってくる", async () => {
-      const ruleMap = new ConditionMap(
+      const ruleMap = await ConditionMap.getInstance(
         `dummyApplicationId100${new Date().getTime()}`,
         {
           source: "redis",
@@ -137,7 +135,7 @@ describe("ConditionMap", function () {
       // 準備
       const appId = `dummyApplicationId100${new Date().getTime()}`;
       const map = [{topic: "dummy", target: "-", actionId: "dummy"}];
-      const dummyRuleMap = new ConditionMap(
+      const dummyRuleMap = await ConditionMap.getInstance(
         appId,
         {
           source: "object",
@@ -149,7 +147,7 @@ describe("ConditionMap", function () {
         config.redis);
       ////
 
-      const ruleMap = new ConditionMap(
+      const ruleMap = await ConditionMap.getInstance(
         appId,
         {
           source: "redis",
@@ -166,7 +164,7 @@ describe("ConditionMap", function () {
   context("fetchForEachRequestオプションがfalseのとき", function () {
     context("#get(mapがない状態)", function () {
       it("source.fetchの結果からmapとextraSlotKeysをとりだす", async function () {
-        const ruleMap = new ConditionMap(
+        const ruleMap = await ConditionMap.getInstance(
           `dummyApplicationId100${new Date().getTime()}`,
           {
             source: "testLocal",
@@ -188,7 +186,7 @@ describe("ConditionMap", function () {
     });
     context("#get(mapがある状態)", function () {
       it("mapをそのまま返す", async function () {
-        const ruleMap = new ConditionMap(
+        const ruleMap = await ConditionMap.getInstance(
           `dummyApplicationId100${new Date().getTime()}`,
           {
             source: "testLocal",
@@ -206,7 +204,7 @@ describe("ConditionMap", function () {
   context("fetchForEachRequestオプションがtrueのとき", function () {
     context("#get(mapがない状態)", function () {
       it("source.fetchの結果からmapとextraSlotKeysをとりだす", async function () {
-        const ruleMap = new ConditionMap(
+        const ruleMap = await ConditionMap.getInstance(
           `dummyApplicationId100${new Date().getTime()}`,
           {
             source: "testLocal",
@@ -228,7 +226,7 @@ describe("ConditionMap", function () {
     });
     context("#get(mapがある状態)", function () {
       it("source.fetchの結果からmapとextraSlotKeysをとりだす", async function () {
-        const ruleMap = new ConditionMap(
+        const ruleMap = await ConditionMap.getInstance(
           `dummyApplicationId101${new Date().getTime()}`,
           {
             source: "testLocal",
@@ -267,22 +265,22 @@ describe("ConditionMap", function () {
 
     it("extraSlotKeysがRedisに保存され、それを読み出せること", async function () {
       optionsBase.extraSlotKeys = ["one", "two", "three"];
-      const ruleMap_save = new ConditionMap(appId, optionsBase, config.redis);
-      const ruleMap_load = new ConditionMap(appId, optionsRedis, config.redis);
+      const ruleMap_save = await ConditionMap.getInstance(appId, optionsBase, config.redis);
+      const ruleMap_load = await ConditionMap.getInstance(appId, optionsRedis, config.redis);
       const extraSlotKeys = await ruleMap_load.getExtraSlotKeys();
       expect(extraSlotKeys).deep.equal(["one", "two", "three"]);
     });
 
     it("Redisに保存されたextraSlotKeysをOverrideできること", async function () {
       optionsRedis.extraSlotKeys = ["three", "one"];
-      const ruleMap_load_1 = new ConditionMap(appId, optionsRedis, config.redis);
+      const ruleMap_load_1 = await ConditionMap.getInstance(appId, optionsRedis, config.redis);
       const extraSlotKeys_1 = await ruleMap_load_1.getExtraSlotKeys();
       expect(extraSlotKeys_1).deep.equal(["three", "one"]);
       delete optionsRedis.extraSlotKeys;
     });
 
     it("OverrideしたextraSlotKeysがRedisに保存されていること", async function () {
-      const ruleMap_load_1 = new ConditionMap(appId, optionsRedis, config.redis);
+      const ruleMap_load_1 = await ConditionMap.getInstance(appId, optionsRedis, config.redis);
       const extraSlotKeys_1 = await ruleMap_load_1.getExtraSlotKeys();
       expect(extraSlotKeys_1).deep.equal(["three", "one"]);
     });

--- a/test/e2e/e2e.spec.js
+++ b/test/e2e/e2e.spec.js
@@ -66,7 +66,7 @@ describe("E2E", function() {
   context("scenario", function () {
     ConditionMap.instance = null;
     it ("正常終了", async ()=>{
-      const m = new DialogueContextManager( testOptions() );
+      const m = await DialogueContextManager.getInstance( testOptions() );
       const ctx1 = await m.getNewContext( userId, generateInput(true, {
         gender: { keyword: "men" } 
       }));
@@ -105,11 +105,11 @@ describe("E2E", function() {
       let exists = await DialogueContextManager.conditionMapExists(fillingApplicationId, config.redis);
       expect(exists).equal(false);
 
-      const _m = new DialogueContextManager( testOptionsForFilling() );
+      const _m = await DialogueContextManager.getInstance( testOptionsForFilling() );
       exists = await DialogueContextManager.conditionMapExists(fillingApplicationId, config.redis);
       expect(exists).equal(true);
 
-      const m = new DialogueContextManager( testOptionsForFillingFromRedis() );
+      const m = await DialogueContextManager.getInstance( testOptionsForFillingFromRedis() );
       const ctx1 = await m.getNewContext( userId, generateInput(true, {
         topic: { id: "order_cake" }
       }));


### PR DESCRIPTION
## 概要

非同期処理を行っているところで、本来必要な待ち合わせができておらず、処理順序が乱れることにより処理が失敗する不具合を修正。

## なぜ気がついたか

遅延の大きな Redis over TLS サーバーに対してテストを行っていたところ、 Redis `SET` 直後に `GET` すると `null` になることがあった。
繰り返しているとまれに成功することがあった。

## やったこと

* コンストラクタから非同期処理を分離
* `new` で呼んでいた上記コンストラクタを `getInstance` メソッドを用意して wrap
* 併せてテストを修正
